### PR TITLE
adds builds for macOS with ARM CPUs ("Apple Silicon"), and runs builds (but no releases) for each commit

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -50,8 +50,29 @@ jobs:
           name: southpark-downloader-ui-linux-amd64
           path: southpark-downloader-ui-linux-amd64.tar.xz
 
-  build-macos:
+  build-macos-apple-silicon:
     runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.20.0
+          cache: true
+      - run: go install fyne.io/fyne/v2/cmd/fyne@latest
+      - run: cd ./cmd/southpark-downloader-ui && fyne package --release
+      - run: mv ./cmd/southpark-downloader-ui/southpark-downloader-ui.app southpark-downloader-ui-macos-arm64.app
+      - run: tar czf southpark-downloader-ui-macos-arm64.tar.gz southpark-downloader-ui-macos-arm64.app
+      - uses: actions/upload-artifact@v4
+        with:
+          name: southpark-downloader-ui-macos-arm64
+          path: southpark-downloader-ui-macos-arm64.tar.gz
+
+  build-macos-intel:
+    # mac os 13 == latest macOS runner for intel, cf.
+    # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
         with:
@@ -71,7 +92,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [build-windows, build-linux, build-macos]
+    needs: [build-windows, build-linux, build-macos-intel, build-macos-apple-silicon]
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -84,6 +105,10 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: southpark-downloader-ui-macos-amd64
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: southpark-downloader-ui-macos-arm64
 
       - uses: actions/create-release@v1
         id: create-new-release
@@ -118,4 +143,13 @@ jobs:
           upload_url: ${{ steps.create-new-release.outputs.upload_url }}
           asset_path: ./southpark-downloader-ui-macos-amd64.tar.gz
           asset_name: southpark-downloader-ui-macos-amd64.tar.gz
+          asset_content_type: application/x-gtar
+
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-new-release.outputs.upload_url }}
+          asset_path: ./southpark-downloader-ui-macos-arm64.tar.gz
+          asset_name: southpark-downloader-ui-macos-arm64.tar.gz
           asset_content_type: application/x-gtar

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
     branches:
-      - 'main'
+      - '**'
     tags:
       - 'v*'
   pull_request:
@@ -91,6 +91,7 @@ jobs:
           path: southpark-downloader-ui-macos-amd64.tar.gz
 
   release:
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs: [build-windows, build-linux, build-macos-intel, build-macos-apple-silicon]
     steps:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ If you have any request or criticism in particular, feel free to open an issue (
 - [Windows (64-bit)](https://github.com/xypwn/southpark-downloader-ui/releases/latest/download/southpark-downloader-ui-windows-amd64.exe)
 - [Linux (64-bit)](https://github.com/xypwn/southpark-downloader-ui/releases/latest/download/southpark-downloader-ui-linux-amd64.tar.xz)
 - [MacOS (Intel)](https://github.com/xypwn/southpark-downloader-ui/releases/latest/download/southpark-downloader-ui-macos-amd64.tar.gz)
+- [MacOS (Apple Silicon)](https://github.com/xypwn/southpark-downloader-ui/releases/latest/download/southpark-downloader-ui-macos-arm64.tar.gz)
 
 ### Windows
 Open the .exe file.


### PR DESCRIPTION
I tried to run the macOS Intel release, and macOS said the binary is not fine and it is suggested to recycle the file...
So I tried to compile your code, and it worked directly without any changes!
(Thanks btw for your awesome tool!)

This PR adds an Apple Silicon/macOS Release to your existing Intel/AM64 releases. It also builds for all platforms for every push, since I needed to test the GH actions... and I think building for alle platforms is nice, anyway, for contributors.