### PR TITLE
adds a "download all" button for a full season pack download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Code coverage profiles and other test artifacts
+*.out
+coverage.*
+*.coverprofile
+profile.cov
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# env file
+.env
+
+# Editor/IDE
+.idea/
+.vscode/
+
+# built binary
+/southpark-downloader-ui
+/southpark-downloader-ui.exe

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If there's no error message, you should now have an executable binary called `so
 - [X] Extract downloader and cache logic into internal package & despaghettify
   - [X] Make downloads persistent after closing the app
 - [X] Allow directly downloading search results & fix search in general
-- [ ] Add 'Download All' button to add all episodes of the season to the queue
+- [X] Add 'Download All' button to add all episodes of the season to the queue
 - [ ] Make Android usable and useful
   - Figure out a way to save files without direct access to SAF
 - [ ] Nitpicks


### PR DESCRIPTION
This PR adds a "Download All" button... After testing, I wanted to have this feature and thought about it; -  then read your readme, which also had this feature on the _Roadmap_... :) 
The button is displayed below the list of episodes when viewing a season.
<img width="1026" alt="Bildschirmfoto 2025-06-04 um 02 21 48" src="https://github.com/user-attachments/assets/e3a1bac0-55a5-41b4-90ca-aa05ab1dab79" />
When clicked, it simply uses your existing implementation and queue to download all episodes by "tapping" them (if they haven't been downloaded yet).

It also checks whether there are any remaining episodes... If all are already downloaded, the button is disabled. If there only some episodes are left, only the episodes, which have not been already been downloaded are downloaded.
The button is also updated during downloads via callbacks.
<img width="1026" alt="Bildschirmfoto 2025-06-04 um 02 21 54" src="https://github.com/user-attachments/assets/1d152304-d581-4891-a513-6625f50635e2" />

**Please note:**
I am not a Go programmer and used AI tools to create this feature. However, I think, if you - a Go programmer - would review this, it is a good starting point.
Especially, (I think) whether updating the `Episode` Struct is a Go best practice, would be something you'd maybe wanna check. 
But, I tried out the solution (on a PC of a good friend outside of the EU) and it works nicely.